### PR TITLE
Added storing original message in file - issue #45

### DIFF
--- a/django_mailbox/migrations/0002_add_eml_to_message.py
+++ b/django_mailbox/migrations/0002_add_eml_to_message.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('django_mailbox', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='message',
+            name='eml',
+            field=models.FileField(help_text='Original full content of message', upload_to=b'', null=True, verbose_name='Message as a file'),
+            preserve_default=True,
+        ),
+    ]

--- a/docs/topics/appendix/settings.rst
+++ b/docs/topics/appendix/settings.rst
@@ -66,3 +66,7 @@ Settings
   * If this is set, it will be read as a number of
     bytes.  Any messages above that size will not be
     downloaded.  ``2000000`` is 2 Megabytes.
+* ``DJANGO_MAILBOX_STORE_ORIGINAL_MESSAGE``
+  * Default: ``False``
+  * Type: ``boolean``
+  * Controls whether or not we store original messages in ``eml`` field


### PR DESCRIPTION
Changes related to issues #45.

In class ``Messages`` added ```File``` named  ```eml``` (migrations created accordingly), updated ```_process_message``` to fill ```eml``` (according to ```DJANGO_MAILBOX_STORE_ORIGINAL_MESSAGE``` accordingly) and ```get_email_object``` to use ```eml``` if filed. Finally, the documentation has been updated to map these changes.